### PR TITLE
Scale orzo to 100g per serving in mushroom risotto

### DIFF
--- a/data/risotto-van-orzo-met-paddenstoelen-en-kruidenkaas/recipe.json
+++ b/data/risotto-van-orzo-met-paddenstoelen-en-kruidenkaas/recipe.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "orzo",
-      "amount": 335,
+      "amount": 400,
       "unit": "g"
     },
     {


### PR DESCRIPTION
## Summary
- Bump orzo from 335g to 400g in `risotto-van-orzo-met-paddenstoelen-en-kruidenkaas` so the 4-serving yield equals 100g per portion.

## Test plan
- [ ] Verify `data/risotto-van-orzo-met-paddenstoelen-en-kruidenkaas/recipe.json` shows orzo at 400g.
- [ ] Confirm recipe still renders correctly in the app.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VshjAvxS4Un8T3iYLVPUCo)_