### PR TITLE
feat: redesign recipe cards and detail page

### DIFF
--- a/.claude/skills/import-recipe/SKILL.md
+++ b/.claude/skills/import-recipe/SKILL.md
@@ -59,22 +59,19 @@ The target shape matches `src/core/types.ts`. Optional fields are truly optional
     { "text": "Instruction step 1." },
     { "text": "Instruction step 2." }
   ],
-  "adaptations": [
-    "Geschaald van 4 naar 2 personen.",
-    "Kip vervangen door tofu."
-  ]
+  "notes": "Kip vervangen door tofu en geschaald van 4 naar 2 personen."
 }
 ```
 
-#### Adaptations
+#### Notes (adaptations)
 
-`adaptations` is an optional string array that records *true* adaptations vs the original source recipe — changes to what the cook actually does or eats. Omit the field entirely when there are none.
+`notes` is an optional **single string** that records *true* adaptations vs the original source recipe — changes to what the cook actually does or eats. Omit the field entirely when there are none. It renders on the recipe page as a handwritten-style note, so write it as one friendly, display-ready Dutch sentence; combine multiple changes into that one sentence.
 
 **Include:**
 - Servings scaling ("Geschaald van 4 naar 2 personen.")
 - Ingredient swaps ("Rundergehakt vervangen door linzen.")
 - Dietary adaptations ("Vegetarisch gemaakt door X.")
-- Format/cookware changes ("Eén grote quiche in plaats van meerdere kleine vormpjes.")
+- Format/cookware changes ("Eén grote quiche in plaats van meerdere kleine vormpjes!")
 
 **Exclude** (these are data-quality fixes, not adaptations):
 - Fixing typos, wrong units, mislabeled fields
@@ -82,7 +79,7 @@ The target shape matches `src/core/types.ts`. Optional fields are truly optional
 - Adding metadata (recipeCategory, times)
 - Clarifying an ambiguous step
 
-Write each adaptation as one short Dutch sentence. Stay factual ("Geschaald van 4 naar 2 personen.") — no reasoning ("Omdat de gebruiker vegetarisch wilde…").
+Keep it factual and readable — no reasoning ("Omdat de gebruiker vegetarisch wilde…"). When there are several changes, join them naturally into one sentence ("Zonder harissa, laurier en olijven, met selderijzout in plaats van verse selder en 3 extra paprika's.").
 
 #### Ingredient parsing
 

--- a/data/chili-sin-carne/recipe.json
+++ b/data/chili-sin-carne/recipe.json
@@ -119,7 +119,5 @@
       "text": "Serveer de chili met rijst, partjes limoen en zure room."
     }
   ],
-  "adaptations": [
-    "Chilipoeder opgetrokken van een snufje naar 1 tl voor meer pit."
-  ]
+  "notes": "Een volle theelepel chilipoeder in plaats van een snufje, voor wat meer pit!"
 }

--- a/data/creamy-pasta-met-kerstomatensaus-en-ricotta/recipe.json
+++ b/data/creamy-pasta-met-kerstomatensaus-en-ricotta/recipe.json
@@ -92,7 +92,5 @@
     }
   ],
   "recipeCuisine": "Italiaans",
-  "adaptations": [
-    "Chilipoeder weggelaten."
-  ]
+  "notes": "Zonder chilipoeder gemaakt."
 }

--- a/data/gnocchi-in-romige-tomatensaus/recipe.json
+++ b/data/gnocchi-in-romige-tomatensaus/recipe.json
@@ -60,7 +60,5 @@
   "cookTime": "PT15M",
   "totalTime": "PT25M",
   "keywords": "pasta, gnocchi, vegetarisch, snel",
-  "adaptations": [
-    "Parmezaanse kaas weggelaten als afwerking."
-  ]
+  "notes": "Zonder parmezaan als afwerking."
 }

--- a/data/parelcouscous-met-kerstomaatjes-en-halloumi/recipe.json
+++ b/data/parelcouscous-met-kerstomaatjes-en-halloumi/recipe.json
@@ -81,7 +81,5 @@
     }
   ],
   "recipeCuisine": "Mediterraans",
-  "adaptations": [
-    "Kerstomaten worden gestoofd in een pot in plaats van in de oven gegaard."
-  ]
+  "notes": "Kerstomaatjes gestoofd in een pot in plaats van gegaard in de oven."
 }

--- a/data/quiche-met-prei-zalm-en-geitenkaas/recipe.json
+++ b/data/quiche-met-prei-zalm-en-geitenkaas/recipe.json
@@ -73,7 +73,5 @@
       "text": "Bak de quiche 25 minuten in de oven, of tot het eimengsel goed gestold is."
     }
   ],
-  "adaptations": [
-    "Eén grote quiche in plaats van meerdere kleine vormpjes."
-  ]
+  "notes": "Wij maken één grote quiche in plaats van meerdere kleine vormpjes!"
 }

--- a/data/spaghetti-met-linzenbolognese/recipe.json
+++ b/data/spaghetti-met-linzenbolognese/recipe.json
@@ -2,6 +2,10 @@
   "name": "Spaghetti met linzenbolognese",
   "slug": "spaghetti-met-linzenbolognese",
   "description": "Een vegan spaghetti met een hartige bolognese van zwarte linzen, wortel, paprika en passata, op smaak gebracht met rozemarijn.",
+  "source": "https://www.colruyt.be/nl/recepten/spaghetti-met-linzenbolognese-en-harissa",
+  "author": {
+    "name": "Colruyt"
+  },
   "recipeCategory": "Hoofdgerecht",
   "recipeCuisine": "Italiaans",
   "keywords": "vegan, vegetarisch, pasta, linzen, bolognese",
@@ -67,11 +71,5 @@
       "text": "Verwijder op het einde de takjes rozemarijn en serveer de spaghetti met de linzenbolognese."
     }
   ],
-  "adaptations": [
-    "Harissa weggelaten.",
-    "Laurier weggelaten.",
-    "Verse selder vervangen door selderijzout.",
-    "Olijven weggelaten.",
-    "3 paprika's toegevoegd."
-  ]
+  "notes": "Zonder harissa, laurier en olijven, met selderijzout in plaats van verse selder en 3 extra paprika's."
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -6,49 +6,42 @@ type Props = {
   recipe: Recipe;
 };
 
+const ClockIcon = ({ className }: { className: string }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
+  </svg>
+);
+
 export const RecipeCard = ({ recipe }: Props) => (
-  <article
-    className="flex flex-col bg-white shadow-lg shadow-primary-600 hover:shadow-xl transition-all rounded-lg overflow-hidden"
-    role="listitem"
-  >
-    <a href={`/r/${recipe.slug}`} className="flex flex-col h-full">
-      <RecipeImage
-        slug={recipe.slug}
-        className="aspect-video object-cover bg-neutral-200"
-        sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
-      />
-      <div className="mx-4 my-2 flex-1 flex flex-col">
-        <footer className="text-secondary-500 text-sm mb-1">
-          {recipe.author?.name && (
-            <address className="not-italic">Door {recipe.author.name}</address>
-          )}
-        </footer>
-        <h2 className="font-bold text-secondary-900 mb-2">{recipe.name}</h2>
-        <div className="mt-2 flex flex-wrap gap-2">
-          {recipe.totalTime && (
-            <time
-              className="px-2 py-0.5 bg-neutral-100 text-neutral-800 rounded-full text-xs"
-              dateTime={recipe.totalTime}
-            >
-              {translateTime(recipe.totalTime)}
-            </time>
-          )}
-          {recipe.recipeCuisine && (
-            <span className="px-2 py-0.5 bg-neutral-100 text-neutral-800 rounded-full text-xs">
-              {recipe.recipeCuisine}
-            </span>
-          )}
-          {recipe.keywords?.split(",").map((keyword, index) => (
-            <span
-              key={index}
-              className="px-2 py-0.5 bg-neutral-100 text-neutral-800 rounded-full text-xs"
-            >
-              {keyword.trim()}
-            </span>
-          ))}
-        </div>
-        <p className="my-2 text-secondary-900 text-sm line-clamp-3">{recipe.description}</p>
+  <article role="listitem">
+    <a href={`/r/${recipe.slug}`} className="group flex flex-col">
+      <div className="relative">
+        <RecipeImage
+          slug={recipe.slug}
+          className="aspect-video w-full rounded-2xl object-cover bg-photo"
+          sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+        />
+        {recipe.totalTime && (
+          <time
+            className="absolute right-2 top-2 flex items-center gap-1 rounded-full bg-ink/60 px-2 py-1 text-xs text-white backdrop-blur-sm"
+            dateTime={recipe.totalTime}
+          >
+            <ClockIcon className="h-3.5 w-3.5" />
+            {translateTime(recipe.totalTime)}
+          </time>
+        )}
       </div>
+      <h2 className="mt-3 font-bold text-ink">{recipe.name}</h2>
+      {recipe.author?.name && (
+        <address className="mt-1 text-sm text-muted not-italic">
+          via <span className="font-semibold text-accent">{recipe.author.name}</span>
+        </address>
+      )}
     </a>
   </article>
 );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -13,9 +13,9 @@ export const SearchBar = ({ searchQuery, onSearchQueryChange }: Props) => (
         placeholder="Zoek recepten..."
         value={searchQuery}
         onChange={(e) => onSearchQueryChange(e.target.value)}
-        className="w-full px-4 py-3 pl-12 text-secondary-900 bg-white rounded-full shadow-lg shadow-primary-600 focus:outline-none transition-colors"
+        className="w-full px-4 py-3 pl-12 text-ink bg-white rounded-full shadow-lg shadow-accent/15 focus:outline-none focus:ring-2 focus:ring-accent transition-all"
       />
-      <SearchIcon className="absolute left-4 top-1/2 transform -translate-y-1/2 text-neutral-400 w-5 h-5" />
+      <SearchIcon className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted w-5 h-5" />
     </div>
   </div>
 );

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -1,6 +1,6 @@
 export const SearchEmptyState = () => (
   <div className="text-center py-16">
-    <div className="text-neutral-400 mb-4"></div>
-    <h3 className="text-neutral-600 mb-2">Geen recepten gevonden</h3>
+    <div className="text-muted mb-4"></div>
+    <h3 className="text-muted mb-2">Geen recepten gevonden</h3>
   </div>
 );

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,7 +15,7 @@ export interface Recipe {
   totalTime?: string;
   recipeIngredient: RecipeIngredient[]; // Structured ingredient list
   recipeInstructions: RecipeInstruction[];
-  adaptations?: string[]; // Changes made vs the original source recipe
+  notes?: string; // Display-friendly note of changes made vs the original source recipe
 }
 
 export interface RecipeIngredient {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,11 +26,11 @@ export default function Document() {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;800&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Caveat:wght@600;700&family=Montserrat:wght@400;500;600;700;800&display=swap"
           rel="stylesheet"
         />
       </Head>
-      <body className="bg-primary-500 min-h-screen min-w-full">
+      <body className="bg-bg text-ink min-h-screen min-w-full">
         <Main />
         <NextScript />
       </body>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,12 +38,15 @@ const Home: NextPage<Props> = ({ recipes }) => {
       </Head>
       <main className="container mx-auto my-16">
         <header className="text-center mb-8">
-          <h1 className="text-secondary-900 font-extrabold text-4xl mb-2">
-            Tweede kookboek van Robrecht
-          </h1>
-          <p className="text-lg text-gray-600">
-            Een compilatie van lekkere recepten, niet van mezelf maar soms aangepast naar smaak.
-          </p>
+          <h1 className="text-ink font-extrabold text-4xl mb-2">Tweede kookboek van Robrecht</h1>
+          <div className="inline-block text-left">
+            <p className="text-lg text-muted">
+              Een compilatie van lekkere recepten, niet van mezelf
+            </p>
+            <p className="mt-1 translate-x-20 -rotate-2 text-right font-handwritten text-2xl text-accent">
+              maar soms aangepast naar smaak!
+            </p>
+          </div>
         </header>
 
         <SearchBar searchQuery={searchQuery} onSearchQueryChange={setSearchQuery} />
@@ -51,10 +54,7 @@ const Home: NextPage<Props> = ({ recipes }) => {
         {filteredRecipes.length === 0 && searchQuery.trim() && <SearchEmptyState />}
 
         {/* Recipe Grid */}
-        <section
-          className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 mt-8"
-          role="list"
-        >
+        <section className="grid gap-8 grid-cols-2 md:grid-cols-3 lg:grid-cols-4 mt-8" role="list">
           {filteredRecipes.map((recipe) => (
             <RecipeCard key={recipe.slug} recipe={recipe} />
           ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,11 +39,11 @@ const Home: NextPage<Props> = ({ recipes }) => {
       <main className="container mx-auto my-16">
         <header className="text-center mb-8">
           <h1 className="text-ink font-extrabold text-4xl mb-2">Tweede kookboek van Robrecht</h1>
-          <div className="inline-block text-left">
+          <div className="inline-block max-w-full px-4 text-left">
             <p className="text-lg text-muted">
               Een compilatie van lekkere recepten, niet van mezelf
             </p>
-            <p className="mt-1 translate-x-20 -rotate-2 text-right font-handwritten text-2xl text-accent">
+            <p className="mt-1 -rotate-2 text-right font-handwritten text-xl text-accent md:translate-x-20 md:text-2xl">
               maar soms aangepast naar smaak!
             </p>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,7 +40,7 @@ const Home: NextPage<Props> = ({ recipes }) => {
         <header className="text-center mb-8">
           <h1 className="text-ink font-extrabold text-4xl mb-2">Tweede kookboek van Robrecht</h1>
           <div className="inline-block max-w-full px-4 text-left">
-            <p className="text-lg text-muted">
+            <p className="text-center text-lg text-muted">
               Een compilatie van lekkere recepten, niet van mezelf
             </p>
             <p className="mt-1 -rotate-2 text-right font-handwritten text-xl text-accent md:translate-x-20 md:text-2xl">

--- a/src/pages/r/[slug].tsx
+++ b/src/pages/r/[slug].tsx
@@ -26,6 +26,23 @@ export const getStaticProps: GetStaticProps<{ recipe: Recipe }> = async ({ param
   return { props: { recipe } };
 };
 
+const ArrowLeftIcon = ({ className }: { className: string }) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 12H5m0 0l6 6m-6-6l6-6"
+    />
+  </svg>
+);
+
 const RecipeDetail: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({ recipe }) => {
   const [servings, setServings] = useState(recipe.recipeYield);
   const [selectedStep, setSelectedStep] = useState<number | null>(null);
@@ -55,8 +72,18 @@ const RecipeDetail: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
     setServings((prev) => Math.max(1, prev + change)); // Prevent servings < 1
   };
 
+  const tags = [recipe.recipeCategory, recipe.recipeCuisine, ...(recipe.keywords?.split(",") ?? [])]
+    .map((tag) => tag?.trim())
+    .filter((tag): tag is string => Boolean(tag));
+
+  const times = [
+    { label: "Totaal", time: recipe.totalTime },
+    { label: "Voorbereiding", time: recipe.prepTime },
+    { label: "Koken", time: recipe.cookTime },
+  ].filter((entry): entry is { label: string; time: string } => Boolean(entry.time));
+
   return (
-    <main className="container mx-auto my-16 text-secondary-900">
+    <main className="mx-auto max-w-[1080px] px-7 pt-8 pb-24 text-ink">
       <Head>
         <title>{`${recipe.name} - Tweede kookboek van Robrecht`}</title>
         <meta
@@ -83,92 +110,99 @@ const RecipeDetail: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
         )}
       </Head>
 
-      <article className="grid grid-cols-1 md:grid-cols-[1fr_2fr] gap-4 lg:gap-8">
-        <figure className="mb-8 md:mb-0">
+      <a
+        href="/"
+        className="mb-7 inline-flex items-center gap-1.5 text-sm font-medium text-muted transition-colors hover:text-accent"
+      >
+        <ArrowLeftIcon className="h-4 w-4" />
+        Alle recepten
+      </a>
+
+      {/* Hero */}
+      <div className="mb-12 grid grid-cols-1 items-start gap-10 md:grid-cols-[0.92fr_1.08fr]">
+        <figure className="relative m-0">
           <RecipeImage
             slug={recipe.slug}
-            className="aspect-video object-cover bg-neutral-200 w-full rounded-lg"
+            className="aspect-[4/3] w-full rounded-2xl bg-photo object-cover"
             priority
-            sizes="(max-width: 768px) 100vw, 33vw"
+            sizes="(max-width: 768px) 100vw, 40vw"
           />
         </figure>
 
-        <header className="md:mx-12">
-          <h1 className="text-4xl font-extrabold mb-4 mt-2 text-pretty max-w-2xl">{recipe.name}</h1>
+        <div>
+          <h1 className="mt-1 text-3xl font-extrabold leading-tight tracking-tight text-pretty md:text-4xl">
+            {recipe.name}
+          </h1>
 
-          <div
-            className="flex flex-wrap gap-2 justify-start mb-6"
-            role="list"
-            aria-label="Categorieën en tags"
-          >
-            {recipe.recipeCategory && (
-              <span
-                className="px-3 py-1 bg-neutral-100 text-neutral-800 rounded-full text-sm"
-                role="listitem"
-              >
-                {recipe.recipeCategory}
-              </span>
-            )}
-            {recipe.recipeCuisine && (
-              <span
-                className="px-3 py-1 bg-neutral-100 text-neutral-800 rounded-full text-sm"
-                role="listitem"
-              >
-                {recipe.recipeCuisine}
-              </span>
-            )}
-            {recipe.keywords?.split(",").map((keyword, index) => (
-              <span
-                key={index}
-                className="px-3 py-1 bg-neutral-100 text-neutral-800 rounded-full text-sm"
-                role="listitem"
-              >
-                {keyword.trim()}
-              </span>
-            ))}
-          </div>
+          {recipe.author?.name && (
+            <p className="mt-5 text-[15px] text-muted">
+              via{" "}
+              {recipe.source ? (
+                <a
+                  href={recipe.source}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold text-accent hover:underline"
+                >
+                  {recipe.author.name}
+                </a>
+              ) : (
+                <span className="font-semibold text-accent">{recipe.author.name}</span>
+              )}
+            </p>
+          )}
 
-          <dl className="flex flex-wrap gap-6 justify-start mb-8">
-            {recipe.totalTime && (
-              <div className="text-sm text-neutral800">
-                <dt className="inline">Totaal </dt>
-                <dd className="inline font-bold text-secondary-900">
-                  <time dateTime={recipe.totalTime}>{translateTime(recipe.totalTime)}</time>
-                </dd>
-              </div>
-            )}
-            {recipe.prepTime && (
-              <div className="text-sm text-neutral800">
-                <dt className="inline">Voorbereiding </dt>
-                <dd className="inline font-bold text-secondary-900">
-                  <time dateTime={recipe.prepTime}>{translateTime(recipe.prepTime)}</time>
-                </dd>
-              </div>
-            )}
-            {recipe.cookTime && (
-              <div className="text-sm text-neutral800">
-                <dt className="inline">Koken </dt>
-                <dd className="inline font-bold text-secondary-900">
-                  <time dateTime={recipe.cookTime}>{translateTime(recipe.cookTime)}</time>
-                </dd>
-              </div>
-            )}
-          </dl>
+          {tags.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2" role="list" aria-label="Categorieën en tags">
+              {tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="rounded-full bg-accent-tint px-3 py-1 text-[13px] font-medium text-accent-dark"
+                  role="listitem"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
 
-          <p className="text-lg text-gray-600 mb-6 max-w-prose text-pretty">{recipe.description}</p>
-        </header>
-        <aside>
-          {recipe.recipeIngredient.length ? (
-            <section className="bg-white shadow-lg shadow-primary-600 rounded-lg sticky top-8 p-8">
-              <h2 className="sr-only">Ingrediënten</h2>
+          {times.length > 0 && (
+            <dl className="mt-6 flex flex-wrap gap-x-8 gap-y-4 border-y border-line py-4">
+              {times.map((entry) => (
+                <div key={entry.label}>
+                  <dt className="text-xs font-semibold uppercase tracking-wider text-muted">
+                    {entry.label}
+                  </dt>
+                  <dd className="mt-0.5 text-xl font-bold">
+                    <time dateTime={entry.time}>{translateTime(entry.time)}</time>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          {recipe.description && (
+            <p className="mt-5 max-w-prose text-sm italic text-[#5f574c] text-pretty">
+              {recipe.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="grid grid-cols-1 items-start gap-10 md:grid-cols-[0.82fr_1.18fr]">
+        {recipe.recipeIngredient.length ? (
+          <aside className="md:sticky md:top-6">
+            <section className="rounded-2xl border border-line bg-surface p-6">
+              <h2 className="text-xl font-bold">Ingrediënten</h2>
               <div
-                className="flex items-center justify-between mb-6 -mx-1.5 p-1.5 rounded-full bg-neutral-100"
+                className="my-4 flex items-center justify-between rounded-full bg-bg p-1.5"
                 role="group"
                 aria-label="Aantal personen aanpassen"
               >
                 <button
                   onClick={() => adjustServings(-1)}
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white border border-neutral-200 text-secondary-900 transition-colors hover:bg-neutral-50 focus-visible:outline-2 focus-visible:outline-secondary-900 disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-line bg-surface text-accent transition-colors hover:border-accent hover:bg-accent hover:text-white focus-visible:outline-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-40"
                   aria-label="Verlaag aantal personen"
                   disabled={servings <= 1}
                 >
@@ -176,25 +210,41 @@ const RecipeDetail: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
                     <path d="M3 9h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                   </svg>
                 </button>
-                <output className="px-4 tabular-nums text-secondary-900" aria-live="polite">
+                <output className="px-4 font-medium tabular-nums" aria-live="polite">
                   {servings} {servings > 1 ? "personen" : "persoon"}
                 </output>
                 <button
                   onClick={() => adjustServings(1)}
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white border border-neutral-200 text-secondary-900 transition-colors hover:bg-neutral-50 focus-visible:outline-2 focus-visible:outline-secondary-900"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-line bg-surface text-accent transition-colors hover:border-accent hover:bg-accent hover:text-white focus-visible:outline-2 focus-visible:outline-accent"
                   aria-label="Verhoog aantal personen"
                 >
                   <svg width="14" height="14" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-                    <path d="M9 3v12M3 9h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    <path
+                      d="M9 3v12M3 9h12"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
                   </svg>
                 </button>
               </div>
-              <ul className="divide-y divide-neutral-200" aria-label="Ingrediënten lijst">
+              <ul aria-label="Ingrediënten lijst">
                 {recipe.recipeIngredient.map((ingredient, index) => (
-                  <li key={index} className="flex justify-between py-1 gap-4">
-                    <span className="flex-1 break-all">{ingredient.name}</span>
+                  <li
+                    key={index}
+                    className="flex justify-between gap-3 border-b border-line py-2.5 text-[15px] last:border-b-0"
+                  >
+                    <span className="flex-1">
+                      {ingredient.name}
+                      {ingredient.note && (
+                        <span className="block text-[13px] text-muted">{ingredient.note}</span>
+                      )}
+                    </span>
                     {ingredient.amount !== undefined ? (
-                      <data className="text-end shrink-0" value={ingredient.amount}>
+                      <data
+                        className="shrink-0 text-end font-semibold text-accent-dark"
+                        value={ingredient.amount}
+                      >
                         {((ingredient.amount / recipe.recipeYield) * servings).toLocaleString(
                           "nl-BE",
                         )}{" "}
@@ -204,58 +254,46 @@ const RecipeDetail: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
                   </li>
                 ))}
               </ul>
-            </section>
-          ) : null}
-        </aside>
 
-        <section className="bg-white shadow-lg shadow-primary-600 rounded-lg px-8 py-4">
-          <h2 className="sr-only">Bereidingswijze</h2>
+              {recipe.notes ? (
+                <p className="mt-5 -rotate-2 font-handwritten text-[21px] leading-tight text-accent">
+                  {recipe.notes}
+                </p>
+              ) : null}
+            </section>
+          </aside>
+        ) : null}
+
+        <section>
+          <h2 className="mb-2 text-xl font-bold">Bereiding</h2>
           {recipe.recipeInstructions.length ? (
-            <ol className="divide-y divide-neutral-200" aria-label="Bereidingsstappen">
+            <ol aria-label="Bereidingsstappen">
               {recipe.recipeInstructions.map((step, index) => (
-                <li key={index}>
+                <li key={index} className="border-b border-line last:border-b-0">
                   <button
                     onClick={() => setSelectedStep(selectedStep === index ? null : index)}
-                    className="flex py-8 px-4 gap-4 items-baseline text-start cursor-auto w-full"
+                    className="flex w-full cursor-pointer items-start gap-4 py-5 text-start"
                     aria-expanded={selectedStep === index}
                     aria-label={`Stap ${index + 1}: ${step.text.substring(0, 50)}...`}
                   >
                     <span
-                      className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-colors ${
-                        selectedStep === index ? "bg-primary-800 text-neutral-50" : "bg-neutral-100"
+                      className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full font-bold transition-colors ${
+                        selectedStep === index
+                          ? "bg-accent text-white"
+                          : "bg-accent-tint text-accent"
                       }`}
                       aria-hidden="true"
                     >
                       {index + 1}
                     </span>
-                    <span className="text-left">{step.text}</span>
+                    <span className="mt-1 text-base">{step.text}</span>
                   </button>
                 </li>
               ))}
             </ol>
           ) : null}
         </section>
-      </article>
-
-      <footer className="text-center text-sm text-gray-600 mb-8 mt-16">
-        {recipe.author?.name && (
-          <p className="font-medium">
-            Recept door <cite>{recipe.author.name}</cite>
-          </p>
-        )}
-        {recipe.source && (
-          <p>
-            <a
-              href={recipe.source}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-gray-600 hover:underline"
-            >
-              Bron: {recipe.source}
-            </a>
-          </p>
-        )}
-      </footer>
+      </div>
     </main>
   );
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,14 +3,17 @@
 @theme {
   --font-*: initial;
   --font-sans: Montserrat, sans-serif;
+  --font-handwritten: Caveat, cursive;
 
-  --color-primary-500: #fbd791;
-  --color-primary-600: #e8c580;
-  --color-primary-800: #77674d;
-
-  --color-secondary-100: #f8fafb;
-  --color-secondary-500: #6f717e;
-  --color-secondary-900: #041339;
+  --color-accent: #1c6b47;
+  --color-accent-dark: #14543a;
+  --color-accent-tint: #e7f0ea;
+  --color-bg: #faf7f2;
+  --color-surface: #ffffff;
+  --color-ink: #2a2724;
+  --color-muted: #8b847a;
+  --color-line: #ece6dc;
+  --color-photo: #e8dfd0;
 }
 
 @utility container {


### PR DESCRIPTION
## Summary
- Rebrand the whole site to the fresh-green / warm off-white palette (new theme tokens: `accent`, `accent-tint`, `bg`, `surface`, `ink`, `muted`, `line`, `photo`)
- Redesign recipe cards: borderless, rounded image with a time pill, title and "via {author}" line; 2 columns on mobile
- Rework the detail page into a hero (photo + title + tags + times + intro) and a two-column ingredients/steps layout
- Add a handwritten Caveat note for recipe adaptations, plus a tilted handwritten accent on the home subtitle
- Rename the `adaptations` field to `notes` (single display-friendly string) across types, page, all recipes, and the import-recipe skill
- Add Colruyt source/author to `spaghetti-met-linzenbolognese`